### PR TITLE
test: expand and optimize regression testing

### DIFF
--- a/test/regression-extract.js
+++ b/test/regression-extract.js
@@ -10,55 +10,44 @@ const tarStream = require('tar-stream');
 
 const pipeline = util.promisify(stream.pipeline);
 
+/** Files to skip regression testing for due to parsing issues. */
 const exclude = [
   // animated
-  'svg/filters-light-04-f.svg',
-  'svg/filters-composite-05-f.svg',
+  'svgs/W3C_SVG_11_TestSuite/svg/filters-light-04-f.svg',
+  'svgs/W3C_SVG_11_TestSuite/svg/filters-composite-05-f.svg',
   // messed gradients
-  'svg/pservers-grad-18-b.svg',
+  'svgs/W3C_SVG_11_TestSuite/svg/pservers-grad-18-b.svg',
   // removing wrapping <g> breaks :first-child pseudo-class
-  'svg/styling-pres-04-f.svg',
+  'svgs/W3C_SVG_11_TestSuite/svg/styling-pres-04-f.svg',
   // rect is converted to path which matches wrong styles
-  'svg/styling-css-08-f.svg',
+  'svgs/W3C_SVG_11_TestSuite/svg/styling-css-08-f.svg',
   // complex selectors are messed because of converting shapes to paths
-  'svg/struct-use-10-f.svg',
-  'svg/struct-use-11-f.svg',
-  'svg/styling-css-01-b.svg',
-  'svg/styling-css-04-f.svg',
+  'svgs/W3C_SVG_11_TestSuite/svg/struct-use-10-f.svg',
+  'svgs/W3C_SVG_11_TestSuite/svg/struct-use-11-f.svg',
+  'svgs/W3C_SVG_11_TestSuite/svg/styling-css-01-b.svg',
+  'svgs/W3C_SVG_11_TestSuite/svg/styling-css-04-f.svg',
   // strange artifact breaks inconsistently  breaks regression tests
-  'svg/filters-conv-05-f.svg',
+  'svgs/W3C_SVG_11_TestSuite/svg/filters-conv-05-f.svg',
 ];
 
 /**
  * @param {string} url
  * @param {string} baseDir
- * @param {RegExp} include
  */
-const extractTarGz = async (url, baseDir, include) => {
+const extractTarGz = async (url, baseDir) => {
   const extract = tarStream.extract();
   extract.on('entry', async (header, stream, next) => {
     const name = header.name;
 
     try {
-      if (include == null || include.test(name)) {
-        if (
-          name.endsWith('.svg') &&
-          !exclude.includes(name) &&
-          !name.startsWith('svg/animate-')
-        ) {
-          const file = path.join(baseDir, name);
-          await fs.promises.mkdir(path.dirname(file), { recursive: true });
-          await pipeline(stream, fs.createWriteStream(file));
-        } else if (name.endsWith('.svgz')) {
-          // .svgz -> .svg
-          const file = path.join(baseDir, name.slice(0, -1));
-          await fs.promises.mkdir(path.dirname(file), { recursive: true });
-          await pipeline(
-            stream,
-            zlib.createGunzip(),
-            fs.createWriteStream(file),
-          );
-        }
+      if (
+        name.endsWith('.svg') &&
+        !exclude.includes(name) &&
+        !name.startsWith('svgs/W3C_SVG_11_TestSuite/svg/animate-')
+      ) {
+        const file = path.join(baseDir, header.name);
+        await fs.promises.mkdir(path.dirname(file), { recursive: true });
+        await pipeline(stream, fs.createWriteStream(file));
       }
     } catch (error) {
       console.error(error);
@@ -73,11 +62,10 @@ const extractTarGz = async (url, baseDir, include) => {
 
 (async () => {
   try {
-    console.info('Downloading W3C SVG 1.1 Test Suite and extracting files');
+    console.info('Downloading SVGO Test Suite and extracting files');
     await extractTarGz(
-      'https://www.w3.org/Graphics/SVG/Test/20110816/archives/W3C_SVG_11_TestSuite.tar.gz',
-      path.join(__dirname, 'regression-fixtures', 'w3c-svg-11-test-suite'),
-      /^svg\//,
+      'https://svg.github.io/svgo-test-suite/svgo-test-suite.tar.gz',
+      path.join(__dirname, 'regression-fixtures'),
     );
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
| Version | Broken Tests | Runtime |
|---|---|---|
| Initial | 262 | 23.4 minutes |
| https://github.com/svg/svgo/pull/1897 | 262 | 20.2 minutes |
| https://github.com/svg/svgo/pull/1898 | 255 | 21.1 minutes |
| https://github.com/svg/svgo/pull/1899 | 255 | 21.0 minutes |
| https://github.com/svg/svgo/pull/1900 | 255 | 20.5 minutes |
| https://github.com/svg/svgo/pull/1903 | 255 | 20.2 minutes |
| https://github.com/svg/svgo/pull/1764 | 255 | 19.5 minutes |
| https://github.com/svg/svgo/pull/1916 | 172 | 19.2 minutes |

This currently takes 12.7 minutes to run locally on my machine.